### PR TITLE
Keystone authentication fails with "400 Bad Request" with older OpenStack implementations

### DIFF
--- a/pkg/api/keystone/keystone_requests.go
+++ b/pkg/api/keystone/keystone_requests.go
@@ -177,6 +177,7 @@ func authenticate(data *Auth_data, b []byte) error {
 	if err != nil {
 		return err
 	}
+	request.Header.Add("Content-Type", "application/json")
 
 	resp, err := GetHttpClient().Do(request)
 	if err != nil {


### PR DESCRIPTION
Attempting to get the Keystone authentication fork up and running against two different OpenStack implementations:

- Kilo (14.0.1 OpenStack Ansible AIO)
- Liberty (8.0.2 RedHat)

Authentication is working fine on Kilo but on our dev cluster running Liberty, it appears to fail. The following is from the Grafana log with DEBUG level on:

```
lvl=dbug msg="perform initial authentication"
lvl=dbug msg=AuthenticateUnscoped()
lvl=dbug msg="Authentication request to URL: [http://172.16.8.10:5000/v3/auth/tokens?nocatalog]"
lvl=dbug msg="Authentication request body: \n[{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"admin\",\"password\":\"********\",\"domain\":{\"name\":\"default\"}}}},\"scope\":\"unscoped\"}}]"
lvl=eror msg="Error while trying to authenticate user" logger=context userId=0 orgId=0 uname= error="Keystone authentication failed: 400 Bad Request"
lvl=eror msg="Request Completed" logger=context userId=0 orgId=0 uname= method=POST path=/login status=500 remote_addr=192.168.7.1 time_ms=8ns size=53
```

Attempting this request in a similar style with curl is a success:

```
curl -X POST -i \
  -H "Content-Type: application/json" \
  -d '
{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","password":"....","domain":{"name":"default"}}}},"scope":"unscoped"}}
' \
  http://172.16.8.10:5000/v3/auth/tokens?nocatalog ; echo
```

But when the Content-Type header is omitted:

```
curl -X POST -i \
  -d '
{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","password":"....","domain":{"name":"default"}}}},"scope":"unscoped"}}
' \
  http://172.16.8.10:5000/v3/auth/tokens?nocatalog ; echo
```

Fails with the following:

```
{
    "error": {
        "code": 400,
        "message": "Expecting to find application/json in Content-Type header - the server could not comply with the request since it is either malformed or otherwise incorrect. The client is assumed to be in error.",
        "title": "Bad Request"
    }
}
```

I can only assume this requirement was relaxed at some point in Keystone?

The attached fix has resolved the problem, though I have not tested it against Kilo yet or anything newer.